### PR TITLE
params need to be awaited

### DIFF
--- a/app/api/feature-requests/[id]/vote/route.ts
+++ b/app/api/feature-requests/[id]/vote/route.ts
@@ -2,7 +2,7 @@ import { type NextRequest, NextResponse } from "next/server"
 import { voteOnFeatureRequest, getFeatureRequestById } from "@/lib/store"
 
 export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
-  const id = params.id
+  const { id } = await params;
 
   try {
     const { direction } = await request.json()


### PR DESCRIPTION
Getting errors accessing the `param.id`, dynamic APIs are now async:
https://nextjs.org/docs/messages/sync-dynamic-apis#possible-ways-to-fix-it